### PR TITLE
Bump version, avoid warnings/file changes during install from source, add gitignore and htaccess in tmp directories 

### DIFF
--- a/app/system/config.php
+++ b/app/system/config.php
@@ -4,7 +4,7 @@ return [
 
     'application' => [
 
-        'version' => '1.0.18'
+        'version' => '1.0.19'
 
     ],
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70164b762a247183a91d7980d31a579e",
+    "content-hash": "2c62049adeb15a25e7721bc091a23206",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biskuit",
-  "license" : "MIT",
+  "license": "MIT",
   "version": "1.0.19",
   "scripts": {
     "install": "bower install && webpack && gulp"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "biskuit",
   "license" : "MIT",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "scripts": {
     "install": "bower install && webpack && gulp"
   },

--- a/tmp/cache/.gitignore
+++ b/tmp/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tmp/logs/.gitignore
+++ b/tmp/logs/.gitignore
@@ -1,0 +1,3 @@
+*
+!.htaccess
+!.gitignore

--- a/tmp/logs/.htaccess
+++ b/tmp/logs/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/tmp/packages/.gitignore
+++ b/tmp/packages/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tmp/sessions/.gitignore
+++ b/tmp/sessions/.gitignore
@@ -1,0 +1,3 @@
+*
+!.htaccess
+!.gitignore

--- a/tmp/sessions/.htaccess
+++ b/tmp/sessions/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/tmp/temp/.gitignore
+++ b/tmp/temp/.gitignore
@@ -1,0 +1,3 @@
+*
+!.htaccess
+!.gitignore

--- a/tmp/temp/.htaccess
+++ b/tmp/temp/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
Smaller changes:
* Bump versions to 1.0.19 which was forgotten when releaseing the last version.
* Update hash in composer.lock file as otherwise warning was shown during installation from source (composer.json was changed during rebrand, but hash was not updated).
* Remove superfluous space in package.json (npm install always removed it and thus after installation package.json was listed as changed file
* Add gitignore and htaccess files in tmp directories. Otherwise access would be possible and temporary changes would be listed as open for push to GitHub.