### PR TITLE
#37 Possibility to overwrite maintenance view in theme.

### DIFF
--- a/app/system/modules/site/src/Event/MaintenanceListener.php
+++ b/app/system/modules/site/src/Event/MaintenanceListener.php
@@ -22,7 +22,7 @@ class MaintenanceListener implements EventSubscriberInterface
 
             $message = $site->config('maintenance.msg') ?: __("We'll be back soon.");
             $logo = $site->config('maintenance.logo') ?: 'app/system/assets/images/biskuit-logo-large-black.svg';
-            $response = App::view('system/theme:views/maintenance.php', compact('message', 'logo'));
+            $response = App::view('system/maintenance.php', compact('message', 'logo'));
 
             $request->attributes->set('_disable_debugbar', true);
 


### PR DESCRIPTION
Provide solution for pagekit/pagekit#748 - Theme Page Overwrites (Custom Maintenance and Error Pages)

System pages can be overwritten by placing a file with the same name in folder `views/system` of the theme extension.